### PR TITLE
docs(readme): Fix Environment Variable `MONGO_URI` to `MONGODB_URI` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ npm install
 ```env
 PORT=5000 # Port number for the server (default: 5000)
 HOST=localhost # Host address for the server (default: localhost)
-MONGO_URI=mongodb://localhost/mpc-lab-x # MongoDB connection URI
+MONGODB_URI=mongodb://localhost/mpc-lab-x # MongoDB connection URI
 JWT_SECRET=secret # Secret key for JWT token generation
 EMAIL_HOST=smtp-relay.brevo.com # SMTP host for sending emails
 EMAIL_PORT=587 # SMTP port for sending emails


### PR DESCRIPTION
### Summary:

Fixed the issue where the `README` environment variable configuration incorrectly referenced `MONGO_URI` instead of `MONGODB_URI`. This issue could lead to confusion or incorrect configuration for users setting up the MongoDB URI.

### Changes:

- Updated the `README` file to correctly reference `MONGODB_URI` as the environment variable for MongoDB configuration.
- Replaced all instances of `MONGO_URI` with `MONGODB_URI` in the environment variable section.
- Ensured that the environment variable documentation is accurate for proper MongoDB setup.