### PR TITLE
fix(routes): Handle Unmatched Routes with `router.use` for Proper 404 Responses

### DIFF
--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -19,7 +19,7 @@ router.use("/tasks", taskRoutes);
 
 router.use("/problems", problemRoutes);
 
-router.get("*", (req, res) => {
+router.use("*", (req, res) => {
   res.notFound();
 });
 


### PR DESCRIPTION
### Summary:

Fixed the issue where unmatched routes were not properly handled, causing incorrect 404 behavior.

### Changes:

- Updated the unmatched routes handler in `index.js` to use `router.use('*', ...)` instead of `router.get('*', ...)`.
- Ensured all unmatched routes return a 404 response with a consistent format.